### PR TITLE
Implement support for multiple vault connections on one project

### DIFF
--- a/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/FailBuildListener.kt
+++ b/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/FailBuildListener.kt
@@ -22,10 +22,14 @@ import org.jetbrains.teamcity.vault.VaultConstants
 class FailBuildListener : AgentLifeCycleAdapter() {
     override fun buildStarted(runningBuild: AgentRunningBuild) {
         val parameters = runningBuild.sharedConfigParameters
-        val url = parameters[VaultConstants.URL_PROPERTY]
+        parameters.keys.filter { it.startsWith(VaultConstants.PARAMETER_PREFIX) && it.endsWith(VaultConstants.URL_PROPERTY_SUFFIX) }
+                .forEach {
 
-        if (url == null || url.isNullOrBlank()) return
+                    val url = parameters[it]
 
-        runningBuild.stopBuild("HashiCorp Vault is not supported on this agent. Please add agent requirement for '${VaultConstants.FEATURE_SUPPORTED_AGENT_PARAMETER}' parameter or run agent using Java 1.8")
+                    if (url == null || url.isNullOrBlank()) return
+
+                    runningBuild.stopBuild("HashiCorp Vault is not supported on this agent. Please add agent requirement for '${VaultConstants.FEATURE_SUPPORTED_AGENT_PARAMETER}' parameter or run agent using Java 1.8")
+                }
     }
 }

--- a/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/FailBuildListener.kt
+++ b/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/FailBuildListener.kt
@@ -18,18 +18,13 @@ package org.jetbrains.teamcity.vault.agent
 import jetbrains.buildServer.agent.AgentLifeCycleAdapter
 import jetbrains.buildServer.agent.AgentRunningBuild
 import org.jetbrains.teamcity.vault.VaultConstants
+import org.jetbrains.teamcity.vault.isUrlParameter
 
 class FailBuildListener : AgentLifeCycleAdapter() {
     override fun buildStarted(runningBuild: AgentRunningBuild) {
         val parameters = runningBuild.sharedConfigParameters
-        parameters.keys.filter { it.startsWith(VaultConstants.PARAMETER_PREFIX) && it.endsWith(VaultConstants.URL_PROPERTY_SUFFIX) }
-                .forEach {
-
-                    val url = parameters[it]
-
-                    if (url == null || url.isNullOrBlank()) return
-
-                    runningBuild.stopBuild("HashiCorp Vault is not supported on this agent. Please add agent requirement for '${VaultConstants.FEATURE_SUPPORTED_AGENT_PARAMETER}' parameter or run agent using Java 1.8")
-                }
+        if (parameters.asSequence().filter { isUrlParameter(it.key) && !it.value.isNullOrBlank() }.any()) {
+            runningBuild.stopBuild("HashiCorp Vault is not supported on this agent. Please add agent requirement for '${VaultConstants.FEATURE_SUPPORTED_AGENT_PARAMETER}' parameter or run agent using Java 1.8")
+        }
     }
 }

--- a/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/VaultBuildFeature.kt
+++ b/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/VaultBuildFeature.kt
@@ -66,7 +66,7 @@ class VaultBuildFeature(dispatcher: EventDispatcher<AgentLifeCycleListener>,
             if(url == null || url.isNullOrBlank())
                 return@forEach
             val logger = runningBuild.buildLogger
-            logger.activity("HashiCorp \"$prefix\" Vault", VaultConstants.FeatureSettings.FEATURE_TYPE) {
+            logger.activity("HashiCorp Vault ($prefix)", VaultConstants.FeatureSettings.FEATURE_TYPE) {
                 val settings = VaultFeatureSettings(prefix, url)
 
                 if (wrapped == null || wrapped.isNullOrEmpty()) {

--- a/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/VaultParametersResolver.kt
+++ b/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/VaultParametersResolver.kt
@@ -37,7 +37,7 @@ class VaultParametersResolver {
     }
 
     fun resolve(build: AgentRunningBuild, settings: VaultFeatureSettings, token: String) {
-        val references = getReleatedParameterReferences(build, settings.parameterPrefix)
+        val references = getReleatedParameterReferences(build, settings.prefix)
         if (references.isEmpty()) {
             LOG.info("There's nothing to resolve")
             return
@@ -45,11 +45,11 @@ class VaultParametersResolver {
         val logger = build.buildLogger
         logger.message("${references.size} Vault ${"reference".pluralize(references)} to resolve: $references")
 
-        val parameters = references.map { VaultParameter.extract(VaultReferencesUtil.getVaultPath(it, settings.parameterPrefix)) }
+        val parameters = references.map { VaultParameter.extract(VaultReferencesUtil.getVaultPath(it, settings.prefix)) }
 
         val replacements = doFetchAndPrepareReplacements(settings, token, parameters, logger)
 
-        replaceParametersReferences(build, replacements, references, settings.parameterPrefix)
+        replaceParametersReferences(build, replacements, references, settings.prefix)
 
         replacements.values.forEach { build.passwordReplacer.addPassword(it) }
     }

--- a/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/VaultParametersResolver.kt
+++ b/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/VaultParametersResolver.kt
@@ -37,7 +37,7 @@ class VaultParametersResolver {
     }
 
     fun resolve(build: AgentRunningBuild, settings: VaultFeatureSettings, token: String) {
-        val references = getReleatedParameterReferences(build)
+        val references = getReleatedParameterReferences(build, settings.parameterPrefix)
         if (references.isEmpty()) {
             LOG.info("There's nothing to resolve")
             return
@@ -45,11 +45,11 @@ class VaultParametersResolver {
         val logger = build.buildLogger
         logger.message("${references.size} Vault ${"reference".pluralize(references)} to resolve: $references")
 
-        val parameters = references.map { VaultParameter.extract(VaultReferencesUtil.getVaultPath(it)) }
+        val parameters = references.map { VaultParameter.extract(VaultReferencesUtil.getVaultPath(it, settings.parameterPrefix)) }
 
         val replacements = doFetchAndPrepareReplacements(settings, token, parameters, logger)
 
-        replaceParametersReferences(build, replacements, references)
+        replaceParametersReferences(build, replacements, references, settings.parameterPrefix)
 
         replacements.values.forEach { build.passwordReplacer.addPassword(it) }
     }
@@ -155,17 +155,17 @@ class VaultParametersResolver {
     }
 
 
-    private fun getReleatedParameterReferences(build: AgentRunningBuild): Collection<String> {
+    private fun getReleatedParameterReferences(build: AgentRunningBuild, prefix: String): Collection<String> {
         val references = HashSet<String>()
-        VaultReferencesUtil.collect(build.sharedConfigParameters, references)
-        VaultReferencesUtil.collect(build.sharedBuildParameters.allParameters, references)
+        VaultReferencesUtil.collect(build.sharedConfigParameters, references, prefix)
+        VaultReferencesUtil.collect(build.sharedBuildParameters.allParameters, references, prefix)
         return references.sorted()
     }
 
-    private fun replaceParametersReferences(build: AgentRunningBuild, replacements: HashMap<String, String>, usages: Collection<String>) {
+    private fun replaceParametersReferences(build: AgentRunningBuild, replacements: HashMap<String, String>, usages: Collection<String>, prefix: String) {
         // usage may not have leading slash
         for (usage in usages) {
-            val replacement = replacements[usage.removePrefix(VaultConstants.VAULT_PARAMETER_PREFIX).ensureHasPrefix("/")]
+            val replacement = replacements[usage.removePrefix(prefix + ":").ensureHasPrefix("/")]
             if (replacement != null) {
                 build.addSharedConfigParameter(usage, replacement)
             }

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultConstants.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultConstants.kt
@@ -25,8 +25,6 @@ object VaultConstants {
     val WRAPPED_TOKEN_PROPERTY = "teamcity.vault.wrapped.token"
     val TOKEN_REFRESH_TIMEOUT_PROPERTY = "teamcity.vault.token.refresh.timeout"
 
-    @JvmField val VAULT_PARAMETER_PREFIX = "vault:"
-
     object AgentEnvironment {
         val VAULT_TOKEN = "VAULT_TOKEN"
         val VAULT_ADDR = "VAULT_ADDR"
@@ -36,6 +34,9 @@ object VaultConstants {
         @JvmField val FEATURE_TYPE = "teamcity-vault"
 
         // Feature settings
+        @JvmField val PARAMETER_PREFIX = "parameter-prefix"
+        @JvmField val DEFAULT_PARAMETER_PREFIX = "vault"
+
         @JvmField val URL = "url"
 
         @JvmField val ENDPOINT = "endpoint"

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultConstants.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultConstants.kt
@@ -26,6 +26,8 @@ object VaultConstants {
     val WRAPPED_TOKEN_PROPERTY_SUFFIX = ".wrapped.token"
     val TOKEN_REFRESH_TIMEOUT_PROPERTY_SUFFIX = ".token.refresh.timeout"
 
+    @JvmField val VAULT_PARAMETER_PREFIX = "vault:"
+
     object AgentEnvironment {
         val VAULT_TOKEN = "VAULT_TOKEN"
         val VAULT_ADDR = "VAULT_ADDR"
@@ -35,8 +37,8 @@ object VaultConstants {
         @JvmField val FEATURE_TYPE = "teamcity-vault"
 
         // Feature settings
-        @JvmField val PARAMETER_PREFIX = "parameter-prefix"
-        @JvmField val DEFAULT_PARAMETER_PREFIX = "vault"
+        @JvmField val NAMESPACE = "namespace"
+        @JvmField val DEFAULT_PARAMETER_NAMESPACE = ""
 
         @JvmField val URL = "url"
 

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultConstants.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultConstants.kt
@@ -21,9 +21,11 @@ import org.springframework.vault.authentication.AppRoleAuthenticationOptions
 object VaultConstants {
     val FEATURE_SUPPORTED_AGENT_PARAMETER = "teamcity.vault.supported"
 
-    val URL_PROPERTY = "teamcity.vault.url"
-    val WRAPPED_TOKEN_PROPERTY = "teamcity.vault.wrapped.token"
-    val TOKEN_REFRESH_TIMEOUT_PROPERTY = "teamcity.vault.token.refresh.timeout"
+    val PARAMETER_PREFIX = "teamcity.vault"
+    val URL_PROPERTY_SUFFIX = ".url"
+    val WRAPPED_TOKEN_SEARCH_REGEX = Regex("teamcity\\.vault\\.([^\\.]+)\\.wrapped\\.token")
+    val WRAPPED_TOKEN_PROPERTY_SUFFIX = ".wrapped.token"
+    val TOKEN_REFRESH_TIMEOUT_PROPERTY_SUFFIX = ".token.refresh.timeout"
 
     object AgentEnvironment {
         val VAULT_TOKEN = "VAULT_TOKEN"

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultConstants.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultConstants.kt
@@ -23,7 +23,6 @@ object VaultConstants {
 
     val PARAMETER_PREFIX = "teamcity.vault"
     val URL_PROPERTY_SUFFIX = ".url"
-    val WRAPPED_TOKEN_SEARCH_REGEX = Regex("teamcity\\.vault\\.([^\\.]+)\\.wrapped\\.token")
     val WRAPPED_TOKEN_PROPERTY_SUFFIX = ".wrapped.token"
     val TOKEN_REFRESH_TIMEOUT_PROPERTY_SUFFIX = ".token.refresh.timeout"
 

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultFeatureSettings.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultFeatureSettings.kt
@@ -15,11 +15,16 @@
  */
 package org.jetbrains.teamcity.vault
 
-data class VaultFeatureSettings(val url: String, val endpoint: String, val roleId: String, val secretId: String) {
+data class VaultFeatureSettings(val parameterPrefix: String, val url: String, val endpoint: String, val roleId: String, val secretId: String) {
 
-    constructor(url: String, roleId: String, secretId: String) : this(url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, roleId, secretId)
+    constructor(parameterPrefix: String, url: String) : this(parameterPrefix, url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, "", "")
+
+    constructor(url: String, roleId: String, secretId: String) : this(VaultConstants.FeatureSettings.DEFAULT_PARAMETER_PREFIX, url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, roleId, secretId)
+
+    constructor(parameterPrefix: String, url: String, roleId: String, secretId: String) : this(parameterPrefix, url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, roleId, secretId)
 
     constructor(map: Map<String, String>) : this(
+            map[VaultConstants.FeatureSettings.PARAMETER_PREFIX] ?: VaultConstants.FeatureSettings.DEFAULT_PARAMETER_PREFIX,
             map[VaultConstants.FeatureSettings.URL] ?: "",
             // Default value to convert from previous config versions
             (map[VaultConstants.FeatureSettings.ENDPOINT] ?: VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH).removePrefix("/"),
@@ -29,6 +34,7 @@ data class VaultFeatureSettings(val url: String, val endpoint: String, val roleI
 
     fun toMap(map: MutableMap<String, String>) {
         map[VaultConstants.FeatureSettings.URL] = url
+        map[VaultConstants.FeatureSettings.PARAMETER_PREFIX] = parameterPrefix
         map[VaultConstants.FeatureSettings.ENDPOINT] = getNormalizedEndpoint()
         map[VaultConstants.FeatureSettings.ROLE_ID] = roleId
         map[VaultConstants.FeatureSettings.SECRET_ID] = secretId
@@ -45,6 +51,7 @@ data class VaultFeatureSettings(val url: String, val endpoint: String, val roleI
     companion object {
         fun getDefaultParameters(): Map<String, String> {
             return mapOf(
+                    VaultConstants.FeatureSettings.PARAMETER_PREFIX to VaultConstants.FeatureSettings.DEFAULT_PARAMETER_PREFIX,
                     VaultConstants.FeatureSettings.AGENT_SUPPORT_REQUIREMENT to VaultConstants.FeatureSettings.AGENT_SUPPORT_REQUIREMENT_VALUE,
                     VaultConstants.FeatureSettings.ENDPOINT to VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH,
                     VaultConstants.FeatureSettings.URL to "http://localhost:8200"

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultFeatureSettings.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultFeatureSettings.kt
@@ -15,16 +15,16 @@
  */
 package org.jetbrains.teamcity.vault
 
-data class VaultFeatureSettings(val prefix: String, val url: String, val endpoint: String, val roleId: String, val secretId: String) {
+data class VaultFeatureSettings(val namespace: String, val url: String, val endpoint: String, val roleId: String, val secretId: String) {
 
-    constructor(prefix: String, url: String) : this(prefix, url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, "", "")
+    constructor(namespace: String, url: String) : this(namespace, url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, "", "")
 
-    constructor(url: String, roleId: String, secretId: String) : this(VaultConstants.FeatureSettings.DEFAULT_PARAMETER_PREFIX, url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, roleId, secretId)
+    constructor(url: String, roleId: String, secretId: String) : this(VaultConstants.FeatureSettings.DEFAULT_PARAMETER_NAMESPACE, url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, roleId, secretId)
 
-    constructor(prefix: String, url: String, roleId: String, secretId: String) : this(prefix, url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, roleId, secretId)
+    constructor(namespace: String, url: String, roleId: String, secretId: String) : this(namespace, url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, roleId, secretId)
 
     constructor(map: Map<String, String>) : this(
-            map[VaultConstants.FeatureSettings.PARAMETER_PREFIX] ?: VaultConstants.FeatureSettings.DEFAULT_PARAMETER_PREFIX,
+            map[VaultConstants.FeatureSettings.NAMESPACE] ?: VaultConstants.FeatureSettings.DEFAULT_PARAMETER_NAMESPACE,
             map[VaultConstants.FeatureSettings.URL] ?: "",
             // Default value to convert from previous config versions
             (map[VaultConstants.FeatureSettings.ENDPOINT] ?: VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH).removePrefix("/"),
@@ -34,7 +34,7 @@ data class VaultFeatureSettings(val prefix: String, val url: String, val endpoin
 
     fun toMap(map: MutableMap<String, String>) {
         map[VaultConstants.FeatureSettings.URL] = url
-        map[VaultConstants.FeatureSettings.PARAMETER_PREFIX] = prefix
+        map[VaultConstants.FeatureSettings.NAMESPACE] = namespace
         map[VaultConstants.FeatureSettings.ENDPOINT] = getNormalizedEndpoint()
         map[VaultConstants.FeatureSettings.ROLE_ID] = roleId
         map[VaultConstants.FeatureSettings.SECRET_ID] = secretId
@@ -51,7 +51,7 @@ data class VaultFeatureSettings(val prefix: String, val url: String, val endpoin
     companion object {
         fun getDefaultParameters(): Map<String, String> {
             return mapOf(
-                    VaultConstants.FeatureSettings.PARAMETER_PREFIX to VaultConstants.FeatureSettings.DEFAULT_PARAMETER_PREFIX,
+                    VaultConstants.FeatureSettings.NAMESPACE to VaultConstants.FeatureSettings.DEFAULT_PARAMETER_NAMESPACE,
                     VaultConstants.FeatureSettings.AGENT_SUPPORT_REQUIREMENT to VaultConstants.FeatureSettings.AGENT_SUPPORT_REQUIREMENT_VALUE,
                     VaultConstants.FeatureSettings.ENDPOINT to VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH,
                     VaultConstants.FeatureSettings.URL to "http://localhost:8200"

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultFeatureSettings.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultFeatureSettings.kt
@@ -15,13 +15,13 @@
  */
 package org.jetbrains.teamcity.vault
 
-data class VaultFeatureSettings(val parameterPrefix: String, val url: String, val endpoint: String, val roleId: String, val secretId: String) {
+data class VaultFeatureSettings(val prefix: String, val url: String, val endpoint: String, val roleId: String, val secretId: String) {
 
-    constructor(parameterPrefix: String, url: String) : this(parameterPrefix, url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, "", "")
+    constructor(prefix: String, url: String) : this(prefix, url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, "", "")
 
     constructor(url: String, roleId: String, secretId: String) : this(VaultConstants.FeatureSettings.DEFAULT_PARAMETER_PREFIX, url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, roleId, secretId)
 
-    constructor(parameterPrefix: String, url: String, roleId: String, secretId: String) : this(parameterPrefix, url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, roleId, secretId)
+    constructor(prefix: String, url: String, roleId: String, secretId: String) : this(prefix, url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, roleId, secretId)
 
     constructor(map: Map<String, String>) : this(
             map[VaultConstants.FeatureSettings.PARAMETER_PREFIX] ?: VaultConstants.FeatureSettings.DEFAULT_PARAMETER_PREFIX,
@@ -34,7 +34,7 @@ data class VaultFeatureSettings(val parameterPrefix: String, val url: String, va
 
     fun toMap(map: MutableMap<String, String>) {
         map[VaultConstants.FeatureSettings.URL] = url
-        map[VaultConstants.FeatureSettings.PARAMETER_PREFIX] = parameterPrefix
+        map[VaultConstants.FeatureSettings.PARAMETER_PREFIX] = prefix
         map[VaultConstants.FeatureSettings.ENDPOINT] = getNormalizedEndpoint()
         map[VaultConstants.FeatureSettings.ROLE_ID] = roleId
         map[VaultConstants.FeatureSettings.SECRET_ID] = secretId

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultReferencesUtil.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultReferencesUtil.kt
@@ -19,10 +19,10 @@ import jetbrains.buildServer.parameters.ReferencesResolverUtil
 
 object VaultReferencesUtil {
 
-    @JvmStatic fun hasReferences(parameters: Map<String, String>, prefixes: Collection<String>): Boolean {
+    @JvmStatic fun hasReferences(parameters: Map<String, String>, prefix: String): Boolean {
         for ((_, value) in parameters) {
             if (!ReferencesResolverUtil.mayContainReference(value)) continue
-            val refs = getVaultReferences(value,prefixes)
+            val refs = getVaultReferences(value,arrayListOf(prefix))
             if (refs.isNotEmpty()) {
                 return true
             }
@@ -31,9 +31,7 @@ object VaultReferencesUtil {
     }
 
     @JvmStatic fun collect(parameters: Map<String, String>, references: MutableCollection<String>, prefix: String, keys: MutableCollection<String>? = null) {
-        val prefixes = ArrayList<String>(1)
-        prefixes.add(prefix)
-        collect(parameters, references, prefixes,keys)
+        collect(parameters, references, arrayListOf(prefix),keys)
     }
     @JvmStatic fun collect(parameters: Map<String, String>, references: MutableCollection<String>, prefixes: Collection<String>, keys: MutableCollection<String>? = null) {
         for ((key, value) in parameters) {

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/util.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/util.kt
@@ -34,19 +34,18 @@ import org.springframework.web.client.RestTemplate
 import org.springframework.web.util.DefaultUriTemplateHandler
 import java.net.URI
 
-fun isDefault(prefix: String): Boolean {
-    return prefix == "" || prefix == VaultConstants.FeatureSettings.DEFAULT_PARAMETER_PREFIX
+fun isDefault(namespace: String): Boolean {
+    return namespace == VaultConstants.FeatureSettings.DEFAULT_PARAMETER_NAMESPACE
 }
 
-fun getEnvPrefix(prefix: String): String {
-    return if (isDefault(prefix)) ""
-    // TODO: Sanitize special symbols in prefix if needed
-    else prefix.toUpperCase() + "_"
+fun getEnvPrefix(namespace: String): String {
+    return if (isDefault(namespace)) ""
+    else namespace.replace("[^a-zA-Z0-9_]".toRegex(), "_").toUpperCase() + "_"
 }
 
-fun getPrefixedParameter(prefix: String, suffix: String): String {
-    if (isDefault(prefix)) return VaultConstants.PARAMETER_PREFIX + suffix
-    return VaultConstants.PARAMETER_PREFIX + ".$prefix" + suffix
+fun getVaultParameterName(namespace: String, suffix: String): String {
+    if (isDefault(namespace)) return VaultConstants.PARAMETER_PREFIX + suffix
+    return VaultConstants.PARAMETER_PREFIX + ".$namespace" + suffix
 }
 
 fun isUrlParameter(value: String) =
@@ -97,12 +96,12 @@ private fun createRestTemplate(): RestTemplate {
     return RestTemplate(converters)
 }
 
-fun isShouldSetEnvParameters(parameters: MutableMap<String, String>, prefix: String): Boolean {
+fun isShouldSetEnvParameters(parameters: MutableMap<String, String>, namespace: String): Boolean {
     if (parameters[VaultConstants.BehaviourParameters.ExposeEnvParameters]?.toBoolean() == true)
         return true
 
-    if (isDefault(prefix)) return false
-    return parameters[VaultConstants.BehaviourParameters.ExposeEnvParameters + "." + prefix]?.toBoolean() ?: false
+    if (isDefault(namespace)) return false
+    return parameters[VaultConstants.BehaviourParameters.ExposeEnvParameters + "." + namespace]?.toBoolean() ?: false
 }
 
 private fun createUriTemplateHandler(endpoint: VaultEndpoint): DefaultUriTemplateHandler {

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/util.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/util.kt
@@ -34,6 +34,12 @@ import org.springframework.web.client.RestTemplate
 import org.springframework.web.util.DefaultUriTemplateHandler
 import java.net.URI
 
+fun prefixOrDefault(prefix: String): String {
+    if (prefix.equals(VaultConstants.FeatureSettings.DEFAULT_PARAMETER_PREFIX))
+        return ""
+    else
+        return ".$prefix"
+}
 
 fun isJava8OrNewer(): Boolean {
     return VersionComparatorUtil.compare(System.getProperty("java.specification.version"), "1.8") >= 0

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/util.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/util.kt
@@ -86,7 +86,12 @@ private fun createRestTemplate(): RestTemplate {
     return RestTemplate(converters)
 }
 
-fun isShouldSetEnvParameters(parameters: MutableMap<String, String>) = parameters[VaultConstants.BehaviourParameters.ExposeEnvParameters]?.toBoolean() ?: false
+fun isShouldSetEnvParameters(parameters: MutableMap<String, String>, prefix: String): Boolean {
+    if(parameters[VaultConstants.BehaviourParameters.ExposeEnvParameters]?.toBoolean() ?: false)
+        return true
+
+    return parameters[VaultConstants.BehaviourParameters.ExposeEnvParameters + "." + prefix]?.toBoolean() ?: false
+}
 
 private fun createUriTemplateHandler(endpoint: VaultEndpoint): DefaultUriTemplateHandler {
     val baseUrl = String.format("%s://%s:%s/%s/", endpoint.scheme, endpoint.host, endpoint.port, "v1")

--- a/common/src/test/kotlin/org/jetbrains/teamcity/vault/VaultReferencesUtilTest.kt
+++ b/common/src/test/kotlin/org/jetbrains/teamcity/vault/VaultReferencesUtilTest.kt
@@ -17,26 +17,29 @@ package org.jetbrains.teamcity.vault
 
 import org.assertj.core.api.BDDAssertions.then
 import org.junit.Test
+import java.util.*
 
 class VaultReferencesUtilTest {
     @Test
     fun testSimpleReference() {
+        val prefixes = Arrays.asList("vault");
         val map = mapOf("a" to "%vault:/test%")
-        then(VaultReferencesUtil.hasReferences(map)).isTrue()
+        then(VaultReferencesUtil.hasReferences(map,prefixes)).isTrue()
         val keys = HashSet<String>()
         val refs = HashSet<String>()
-        VaultReferencesUtil.collect(map, refs, Arrays.asList("vault"), keys)
+        VaultReferencesUtil.collect(map, refs, prefixes, keys)
         then(keys).containsOnly(map.keys.first())
         then(refs).containsOnly("vault:/test")
     }
 
     @Test
     fun testManyReferencesInOneParameter() {
+        val prefixes = Arrays.asList("vault");
         val map = mapOf("a" to "%vault:/testA% %vault:/test B%")
-        then(VaultReferencesUtil.hasReferences(map)).isTrue()
+        then(VaultReferencesUtil.hasReferences(map,prefixes)).isTrue()
         val keys = HashSet<String>()
         val refs = HashSet<String>()
-        VaultReferencesUtil.collect(map, refs, Arrays.asList("vault"), keys)
+        VaultReferencesUtil.collect(map, refs, prefixes, keys)
         then(keys).containsOnly(map.keys.first())
         then(refs).containsOnly("vault:/testA", "vault:/test B")
     }

--- a/common/src/test/kotlin/org/jetbrains/teamcity/vault/VaultReferencesUtilTest.kt
+++ b/common/src/test/kotlin/org/jetbrains/teamcity/vault/VaultReferencesUtilTest.kt
@@ -25,7 +25,7 @@ class VaultReferencesUtilTest {
         then(VaultReferencesUtil.hasReferences(map)).isTrue()
         val keys = HashSet<String>()
         val refs = HashSet<String>()
-        VaultReferencesUtil.collect(map, refs, keys)
+        VaultReferencesUtil.collect(map, refs, Arrays.asList("vault"), keys)
         then(keys).containsOnly(map.keys.first())
         then(refs).containsOnly("vault:/test")
     }
@@ -36,7 +36,7 @@ class VaultReferencesUtilTest {
         then(VaultReferencesUtil.hasReferences(map)).isTrue()
         val keys = HashSet<String>()
         val refs = HashSet<String>()
-        VaultReferencesUtil.collect(map, refs, keys)
+        VaultReferencesUtil.collect(map, refs, Arrays.asList("vault"), keys)
         then(keys).containsOnly(map.keys.first())
         then(refs).containsOnly("vault:/testA", "vault:/test B")
     }

--- a/common/src/test/kotlin/org/jetbrains/teamcity/vault/VaultReferencesUtilTest.kt
+++ b/common/src/test/kotlin/org/jetbrains/teamcity/vault/VaultReferencesUtilTest.kt
@@ -22,24 +22,24 @@ import java.util.*
 class VaultReferencesUtilTest {
     @Test
     fun testSimpleReference() {
-        val prefixes = Arrays.asList("vault");
+        val prefix = "vault"
         val map = mapOf("a" to "%vault:/test%")
-        then(VaultReferencesUtil.hasReferences(map,prefixes)).isTrue()
+        then(VaultReferencesUtil.hasReferences(map,prefix)).isTrue()
         val keys = HashSet<String>()
         val refs = HashSet<String>()
-        VaultReferencesUtil.collect(map, refs, prefixes, keys)
+        VaultReferencesUtil.collect(map, refs, prefix, keys)
         then(keys).containsOnly(map.keys.first())
         then(refs).containsOnly("vault:/test")
     }
 
     @Test
     fun testManyReferencesInOneParameter() {
-        val prefixes = Arrays.asList("vault");
+        val prefix = "vault"
         val map = mapOf("a" to "%vault:/testA% %vault:/test B%")
-        then(VaultReferencesUtil.hasReferences(map,prefixes)).isTrue()
+        then(VaultReferencesUtil.hasReferences(map,prefix)).isTrue()
         val keys = HashSet<String>()
         val refs = HashSet<String>()
-        VaultReferencesUtil.collect(map, refs, prefixes, keys)
+        VaultReferencesUtil.collect(map, refs, prefix, keys)
         then(keys).containsOnly(map.keys.first())
         then(refs).containsOnly("vault:/testA", "vault:/test B")
     }

--- a/common/src/test/kotlin/org/jetbrains/teamcity/vault/VaultReferencesUtilTest.kt
+++ b/common/src/test/kotlin/org/jetbrains/teamcity/vault/VaultReferencesUtilTest.kt
@@ -22,25 +22,79 @@ import java.util.*
 class VaultReferencesUtilTest {
     @Test
     fun testSimpleReference() {
-        val prefix = "vault"
+        val namespaces = listOf("")
         val map = mapOf("a" to "%vault:/test%")
-        then(VaultReferencesUtil.hasReferences(map, prefix)).isTrue()
+        then(VaultReferencesUtil.hasReferences(map, namespaces)).isTrue()
         val keys = HashSet<String>()
         val refs = HashSet<String>()
-        VaultReferencesUtil.collect(map, refs, prefix, keys)
+        VaultReferencesUtil.collect(map, refs, namespaces, keys)
         then(keys).containsOnly(map.keys.first())
         then(refs).containsOnly("vault:/test")
     }
 
     @Test
     fun testManyReferencesInOneParameter() {
-        val prefix = "vault"
+        val namespaces = listOf("")
         val map = mapOf("a" to "%vault:/testA% %vault:/test B%")
-        then(VaultReferencesUtil.hasReferences(map, prefix)).isTrue()
+        then(VaultReferencesUtil.hasReferences(map, namespaces)).isTrue()
         val keys = HashSet<String>()
         val refs = HashSet<String>()
-        VaultReferencesUtil.collect(map, refs, prefix, keys)
+        VaultReferencesUtil.collect(map, refs, namespaces, keys)
         then(keys).containsOnly(map.keys.first())
         then(refs).containsOnly("vault:/testA", "vault:/test B")
+    }
+
+    @Test
+    fun testReferencesWithDifferentPrefixes() {
+        val namespaces = listOf("", "first", "second")
+        val map = mapOf("a" to "%vault:first:/test%", "b" to "%vault:second:/test%", "c" to "%vault:/default%")
+        then(VaultReferencesUtil.hasReferences(map, namespaces)).isTrue()
+        val keys = HashSet<String>()
+        val refs = HashSet<String>()
+        VaultReferencesUtil.collect(map, refs, namespaces, keys)
+        then(keys).containsOnlyElementsOf(map.keys)
+        then(refs).containsOnly("vault:first:/test", "vault:second:/test", "vault:/default")
+    }
+
+    @Test
+    fun testReferencesWithOtherPrefixiesNotSelected() {
+        val namespaces = listOf("")
+        val map = mapOf("a" to "%vault:first:/test%", "b" to "%vault:second:/test%", "c" to "%vault:/default%")
+        then(VaultReferencesUtil.hasReferences(map, namespaces)).isTrue()
+        val keys = HashSet<String>()
+        val refs = HashSet<String>()
+        VaultReferencesUtil.collect(map, refs, namespaces, keys)
+        then(keys).containsOnly("c")
+        then(refs).containsOnly("vault:/default")
+    }
+
+    @Test
+    fun testPathExtractedCorrectly() {
+        doVaultPathTest("first", "vault:first:/test", "/test")
+        doVaultPathTest("second", "vault:second:/test", "/test")
+        doVaultPathTest("", "vault:/test", "/test")
+        doVaultPathTest("", "vault:/test!/inner", "/test!/inner")
+
+        // Adds leading slash
+        doVaultPathTest("", "vault:test", "/test")
+        doVaultPathTest("", "vault:test!/inner", "/test!/inner")
+    }
+
+    private fun doVaultPathTest(namespace: String, text: String, expected: String) {
+        then(VaultReferencesUtil.getPath(text, namespace)).isEqualTo(expected)
+        then(VaultReferencesUtil.getPath(text, VaultReferencesUtil.getNamespace(text))).isEqualTo(expected)
+    }
+
+    @Test
+    fun testVaultNamespaceDetection() {
+        doNamespaceTest("vault:/path", "")
+        doNamespaceTest("vault:ns:/path", "ns")
+
+        doNamespaceTest("vault:/path:with:colons", "")
+        doNamespaceTest("vault:ns:path:with:colons", "ns")
+    }
+
+    private fun doNamespaceTest(string: String, expected: String) {
+        then(VaultReferencesUtil.getNamespace(string)).isEqualTo(expected)
     }
 }

--- a/common/src/test/kotlin/org/jetbrains/teamcity/vault/VaultReferencesUtilTest.kt
+++ b/common/src/test/kotlin/org/jetbrains/teamcity/vault/VaultReferencesUtilTest.kt
@@ -24,7 +24,7 @@ class VaultReferencesUtilTest {
     fun testSimpleReference() {
         val prefix = "vault"
         val map = mapOf("a" to "%vault:/test%")
-        then(VaultReferencesUtil.hasReferences(map,prefix)).isTrue()
+        then(VaultReferencesUtil.hasReferences(map, prefix)).isTrue()
         val keys = HashSet<String>()
         val refs = HashSet<String>()
         VaultReferencesUtil.collect(map, refs, prefix, keys)
@@ -36,7 +36,7 @@ class VaultReferencesUtilTest {
     fun testManyReferencesInOneParameter() {
         val prefix = "vault"
         val map = mapOf("a" to "%vault:/testA% %vault:/test B%")
-        then(VaultReferencesUtil.hasReferences(map,prefix)).isTrue()
+        then(VaultReferencesUtil.hasReferences(map, prefix)).isTrue()
         val keys = HashSet<String>()
         val refs = HashSet<String>()
         VaultReferencesUtil.collect(map, refs, prefix, keys)

--- a/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultBuildStartContextProcessor.kt
+++ b/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultBuildStartContextProcessor.kt
@@ -40,6 +40,13 @@ class VaultBuildStartContextProcessor(private val connector: VaultConnector) : B
             val vaultFeatures = connectionFeatures.map {
                 VaultFeatureSettings(it.parameters)
             }
+            vaultFeatures.groupBy { it.parameterPrefix }.forEach { (prefix, prefixes) ->
+                if(prefixes.size > 1) {
+                    build.addBuildProblem(BuildProblemData.createBuildProblem("VC_${build.buildTypeId}", "VaultConnection",
+                        "Multiple vault connections with prefix \"$prefix\" present"
+                    ))
+                }
+            }
             return vaultFeatures
         }
 

--- a/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultConnector.kt
+++ b/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultConnector.kt
@@ -249,22 +249,22 @@ class VaultConnector(dispatcher: EventDispatcher<BuildServerListener>) {
 
     fun requestWrappedToken(build: SBuild, settings: VaultFeatureSettings): String {
         val infos = myBuildsTokens.getOrDefault(build.buildId,ConcurrentHashMap())
-        val info = infos[settings.prefix]
+        val info = infos[settings.namespace]
         if(info != null) return info.wrapped
 
         myLocks.get(build.buildId).withLock {
             @Suppress("NAME_SHADOWING")
             val infos = myBuildsTokens.getOrDefault(build.buildId,ConcurrentHashMap())
             @Suppress("NAME_SHADOWING")
-            val info = infos[settings.prefix]
+            val info = infos[settings.namespace]
             if(info != null) return info.wrapped
             try {
                 val (token, accessor) = doRequestWrappedToken(settings)
-                infos[settings.prefix] = LeasedWrappedTokenInfo(token, accessor, settings);
+                infos[settings.namespace] = LeasedWrappedTokenInfo(token, accessor, settings);
                 myBuildsTokens[build.buildId] = infos;
                 return token
             } catch (e: Exception) {
-                infos[settings.prefix] = LeasedWrappedTokenInfo.FAILED_TO_FETCH
+                infos[settings.namespace] = LeasedWrappedTokenInfo.FAILED_TO_FETCH
                 myBuildsTokens[build.buildId] = infos;
                 throw e
             }

--- a/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultConnector.kt
+++ b/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultConnector.kt
@@ -249,22 +249,22 @@ class VaultConnector(dispatcher: EventDispatcher<BuildServerListener>) {
 
     fun requestWrappedToken(build: SBuild, settings: VaultFeatureSettings): String {
         val infos = myBuildsTokens.getOrDefault(build.buildId,ConcurrentHashMap())
-        val info = infos[settings.parameterPrefix]
+        val info = infos[settings.prefix]
         if(info != null) return info.wrapped
 
         myLocks.get(build.buildId).withLock {
             @Suppress("NAME_SHADOWING")
             val infos = myBuildsTokens.getOrDefault(build.buildId,ConcurrentHashMap())
             @Suppress("NAME_SHADOWING")
-            val info = infos[settings.parameterPrefix]
+            val info = infos[settings.prefix]
             if(info != null) return info.wrapped
             try {
                 val (token, accessor) = doRequestWrappedToken(settings)
-                infos[settings.parameterPrefix] = LeasedWrappedTokenInfo(token, accessor, settings);
+                infos[settings.prefix] = LeasedWrappedTokenInfo(token, accessor, settings);
                 myBuildsTokens[build.buildId] = infos;
                 return token
             } catch (e: Exception) {
-                infos[settings.parameterPrefix] = LeasedWrappedTokenInfo.FAILED_TO_FETCH
+                infos[settings.prefix] = LeasedWrappedTokenInfo.FAILED_TO_FETCH
                 myBuildsTokens[build.buildId] = infos;
                 throw e
             }

--- a/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultJspKeys.kt
+++ b/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultJspKeys.kt
@@ -18,7 +18,7 @@ package org.jetbrains.teamcity.vault.server
 import org.jetbrains.teamcity.vault.VaultConstants
 
 class VaultJspKeys {
-    val PARAMETER_PREFIX = VaultConstants.FeatureSettings.PARAMETER_PREFIX
+    val NAMESPACE = VaultConstants.FeatureSettings.NAMESPACE
     val URL = VaultConstants.FeatureSettings.URL
 
     val ENDPOINT = VaultConstants.FeatureSettings.ENDPOINT

--- a/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultJspKeys.kt
+++ b/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultJspKeys.kt
@@ -18,6 +18,7 @@ package org.jetbrains.teamcity.vault.server
 import org.jetbrains.teamcity.vault.VaultConstants
 
 class VaultJspKeys {
+    val PARAMETER_PREFIX = VaultConstants.FeatureSettings.PARAMETER_PREFIX
     val URL = VaultConstants.FeatureSettings.URL
 
     val ENDPOINT = VaultConstants.FeatureSettings.ENDPOINT

--- a/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultParametersProvider.kt
+++ b/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultParametersProvider.kt
@@ -19,10 +19,7 @@ import jetbrains.buildServer.agent.Constants
 import jetbrains.buildServer.serverSide.SBuild
 import jetbrains.buildServer.serverSide.oauth.OAuthConstants
 import jetbrains.buildServer.serverSide.parameters.AbstractBuildParametersProvider
-import org.jetbrains.teamcity.vault.VaultConstants
-import org.jetbrains.teamcity.vault.VaultReferencesUtil
-import org.jetbrains.teamcity.vault.isShouldSetEnvParameters
-import org.jetbrains.teamcity.vault.VaultFeatureSettings
+import org.jetbrains.teamcity.vault.*
 
 class VaultParametersProvider : AbstractBuildParametersProvider() {
     companion object {
@@ -32,8 +29,8 @@ class VaultParametersProvider : AbstractBuildParametersProvider() {
 
             // It's faster than asking OAuthConectionsManager
             if (project.getAvailableFeaturesOfType(OAuthConstants.FEATURE_TYPE).any {
-                VaultConstants.FeatureSettings.FEATURE_TYPE == it.parameters[OAuthConstants.OAUTH_TYPE_PARAM]
-            }) return true
+                        VaultConstants.FeatureSettings.FEATURE_TYPE == it.parameters[OAuthConstants.OAUTH_TYPE_PARAM]
+                    }) return true
 
             return false
         }
@@ -54,14 +51,11 @@ class VaultParametersProvider : AbstractBuildParametersProvider() {
             VaultFeatureSettings(it.parameters)
         }
         val parameters = build.buildOwnParameters
-        vaultFeatures.forEach {feature: VaultFeatureSettings ->
-
-            val envPrefix = if(feature.prefix.equals(VaultConstants.FeatureSettings.DEFAULT_PARAMETER_PREFIX))
-                ""
-            else
-                feature.prefix.toUpperCase() + "_"
+        vaultFeatures.forEach { feature: VaultFeatureSettings ->
 
             if (isShouldSetEnvParameters(parameters, feature.prefix)) {
+                val envPrefix = getEnvPrefix(feature.prefix)
+
                 exposed += Constants.ENV_PREFIX + envPrefix + VaultConstants.AgentEnvironment.VAULT_TOKEN
                 exposed += Constants.ENV_PREFIX + envPrefix + VaultConstants.AgentEnvironment.VAULT_ADDR
             }

--- a/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultParametersProvider.kt
+++ b/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultParametersProvider.kt
@@ -61,7 +61,7 @@ class VaultParametersProvider : AbstractBuildParametersProvider() {
             else
                 feature.prefix.toUpperCase() + "_"
 
-            if (isShouldSetEnvParameters(parameters)) {
+            if (isShouldSetEnvParameters(parameters, feature.prefix)) {
                 exposed += Constants.ENV_PREFIX + envPrefix + VaultConstants.AgentEnvironment.VAULT_TOKEN
                 exposed += Constants.ENV_PREFIX + envPrefix + VaultConstants.AgentEnvironment.VAULT_ADDR
             }

--- a/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultParametersProvider.kt
+++ b/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultParametersProvider.kt
@@ -53,14 +53,14 @@ class VaultParametersProvider : AbstractBuildParametersProvider() {
         val parameters = build.buildOwnParameters
         vaultFeatures.forEach { feature: VaultFeatureSettings ->
 
-            if (isShouldSetEnvParameters(parameters, feature.prefix)) {
-                val envPrefix = getEnvPrefix(feature.prefix)
+            if (isShouldSetEnvParameters(parameters, feature.namespace)) {
+                val envPrefix = getEnvPrefix(feature.namespace)
 
                 exposed += Constants.ENV_PREFIX + envPrefix + VaultConstants.AgentEnvironment.VAULT_TOKEN
                 exposed += Constants.ENV_PREFIX + envPrefix + VaultConstants.AgentEnvironment.VAULT_ADDR
             }
         }
-        VaultReferencesUtil.collect(parameters, exposed, vaultFeatures.map { feature -> feature.prefix })
+        VaultReferencesUtil.collect(parameters, exposed, vaultFeatures.map { feature -> feature.namespace })
         return exposed
     }
 }

--- a/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultProjectConnectionProvider.kt
+++ b/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultProjectConnectionProvider.kt
@@ -36,7 +36,8 @@ class VaultProjectConnectionProvider(private val descriptor: PluginDescriptor) :
     override fun getDefaultProperties(): Map<String, String> {
         return mapOf(
                 VaultConstants.FeatureSettings.ENDPOINT to VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH,
-                VaultConstants.FeatureSettings.URL to "http://localhost:8200"
+                VaultConstants.FeatureSettings.URL to "http://localhost:8200",
+                VaultConstants.FeatureSettings.PARAMETER_PREFIX to VaultConstants.FeatureSettings.DEFAULT_PARAMETER_PREFIX
         )
     }
 
@@ -54,6 +55,9 @@ class VaultProjectConnectionProvider(private val descriptor: PluginDescriptor) :
                 val errors = ArrayList<InvalidProperty>()
                 if (it[VaultConstants.FeatureSettings.URL].isNullOrBlank()) {
                     errors.add(InvalidProperty(VaultConstants.FeatureSettings.URL, "Should not be empty"))
+                }
+                if (it[VaultConstants.FeatureSettings.PARAMETER_PREFIX].isNullOrBlank()) {
+                    errors.add(InvalidProperty(VaultConstants.FeatureSettings.PARAMETER_PREFIX, "Should not be empty"))
                 }
                 if (it[VaultConstants.FeatureSettings.ENDPOINT].isNullOrBlank()) {
                     errors.add(InvalidProperty(VaultConstants.FeatureSettings.ENDPOINT, "Should not be empty"))

--- a/server/src/main/resources/buildServerResources/editProjectConnectionVault.jsp
+++ b/server/src/main/resources/buildServerResources/editProjectConnectionVault.jsp
@@ -77,11 +77,11 @@
     </td>
 </tr>
 <tr>
-    <td><label for="${keys.PARAMETER_PREFIX}">Parameter prefix:</label><l:star/></td>
+    <td><label for="${keys.NAMESPACE}">Parameter namespace:</label></td>
     <td>
-        <props:textProperty name="${keys.PARAMETER_PREFIX}" className="longField"/>
-        <span class="error" id="error_${keys.PARAMETER_PREFIX}"></span>
-        <span class="smallNote">Provide some prefix to use in parameters in case of multiple vault connections.</span>
+        <props:textProperty name="${keys.NAMESPACE}" className="longField"/>
+        <span class="error" id="error_${keys.NAMESPACE}"></span>
+        <span class="smallNote">Provide some namespace to use in parameters in case of multiple vault connections.</span>
     </td>
 </tr>
 <tr>

--- a/server/src/main/resources/buildServerResources/editProjectConnectionVault.jsp
+++ b/server/src/main/resources/buildServerResources/editProjectConnectionVault.jsp
@@ -77,6 +77,14 @@
     </td>
 </tr>
 <tr>
+    <td><label for="${keys.PARAMETER_PREFIX}">Parameter prefix:</label><l:star/></td>
+    <td>
+        <props:textProperty name="${keys.PARAMETER_PREFIX}" className="longField"/>
+        <span class="error" id="error_${keys.PARAMETER_PREFIX}"></span>
+        <span class="smallNote">Provide some prefix to use in parameters in case of multiple vault connections.</span>
+    </td>
+</tr>
+<tr>
     <td><label for="${keys.URL}">Vault URL:</label></td>
     <td>
         <props:textProperty name="${keys.URL}"

--- a/server/src/test/java/org/jetbrains/teamcity/vault/server/VaultConnectorTest.java
+++ b/server/src/test/java/org/jetbrains/teamcity/vault/server/VaultConnectorTest.java
@@ -88,7 +88,7 @@ public class VaultConnectorTest {
         Pair<String, String> credentials = getAppRoleCredentials(template, "auth/" + authMountPath + "/role/testrole");
 
 
-        final Pair<String, String> wrapped = VaultConnector.doRequestWrappedToken(new VaultFeatureSettings(getVault().getUrl(), authMountPath, credentials.getFirst(), credentials.getSecond()));
+        final Pair<String, String> wrapped = VaultConnector.doRequestWrappedToken(new VaultFeatureSettings("vault", getVault().getUrl(), authMountPath, credentials.getFirst(), credentials.getSecond()));
 
         then(wrapped.getFirst()).isNotNull();
         then(wrapped.getSecond()).isNotNull();
@@ -98,7 +98,7 @@ public class VaultConnectorTest {
                 .wrapped()
                 .initialToken(VaultToken.of(wrapped.getFirst()))
                 .build();
-        final RestTemplate simpleTemplate = UtilKt.createRestTemplate(new VaultFeatureSettings(getVault().getUrl(), authMountPath, "", ""));
+        final RestTemplate simpleTemplate = UtilKt.createRestTemplate(new VaultFeatureSettings("vault", getVault().getUrl(), authMountPath, "", ""));
         final CubbyholeAuthentication authentication = new CubbyholeAuthentication(options, simpleTemplate);
         final TaskScheduler scheduler = new ConcurrentTaskScheduler();
 


### PR DESCRIPTION
This implements support for multiple namespaced vault connections. This should solve issue #10 as well.
This is a breaking change in the sense that the env parameter for the vault token has changed. I can implement backwards compatibility in the cases where only one connection is specified.

What do you think?