### PR TITLE
Add Vault Namespace Support

### DIFF
--- a/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/VaultBuildFeature.kt
+++ b/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/VaultBuildFeature.kt
@@ -68,6 +68,7 @@ class VaultBuildFeature(dispatcher: EventDispatcher<AgentLifeCycleListener>,
         namespaces.forEach { namespace ->
             // namespace is either empty string or something like 'id'
             val url = parameters[getVaultParameterName(namespace, VaultConstants.URL_PROPERTY_SUFFIX)]
+            val vaultNamespace = parameters[getVaultParameterName(namespace, VaultConstants.VAULT_NAMESPACE_PROPERTY_SUFFIX)] ?: ""
             val wrapped = parameters[getVaultParameterName(namespace, VaultConstants.WRAPPED_TOKEN_PROPERTY_SUFFIX)]
             val failOnError = parameters[getVaultParameterName(namespace, VaultConstants.FAIL_ON_ERROR_PROPERTY_SUFFIX)]
                     ?.toBoolean() ?: false
@@ -77,7 +78,7 @@ class VaultBuildFeature(dispatcher: EventDispatcher<AgentLifeCycleListener>,
             }
             val logger = runningBuild.buildLogger
             logger.activity("HashiCorp Vault" + if (isDefault(namespace)) "" else " ('$namespace' namespace)", VaultConstants.FeatureSettings.FEATURE_TYPE) {
-                val settings = VaultFeatureSettings(namespace, url, failOnError)
+                val settings = VaultFeatureSettings(namespace, url, vaultNamespace, failOnError)
 
                 if (wrapped == null || wrapped.isNullOrEmpty()) {
                     logger.internalError(VaultConstants.FeatureSettings.FEATURE_TYPE, "Wrapped HashiCorp Vault token for url $url not found", null)
@@ -139,4 +140,3 @@ class VaultBuildFeature(dispatcher: EventDispatcher<AgentLifeCycleListener>,
         sessions.remove(build.buildId)
     }
 }
-

--- a/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/VaultParametersResolver.kt
+++ b/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/VaultParametersResolver.kt
@@ -65,7 +65,7 @@ class VaultParametersResolver(private val trustStoreProvider: SSLTrustStoreProvi
     fun doFetchAndPrepareReplacements(settings: VaultFeatureSettings, token: String, parameters: List<VaultParameter>, logger: BuildProgressLogger): ResolvingResult {
         val endpoint = VaultEndpoint.from(URI.create(settings.url))
         val factory = createClientHttpRequestFactory(trustStoreProvider)
-        val client = VaultTemplate(endpoint, factory, SimpleSessionManager({ VaultToken.of(token) }))
+        val client = VaultTemplate(endpoint, settings.vaultNamespace, factory, SimpleSessionManager({ VaultToken.of(token) }))
 
         return doFetchAndPrepareReplacements(client, parameters, logger)
     }

--- a/common/src/main/java/org/jetbrains/teamcity/vault/support/VaultInterceptors.java
+++ b/common/src/main/java/org/jetbrains/teamcity/vault/support/VaultInterceptors.java
@@ -1,0 +1,29 @@
+package org.jetbrains.teamcity.vault.support;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpResponse;
+import java.io.IOException;
+
+public class VaultInterceptors {
+    public static final String VAULT_NAMESPACE = "X-Vault-Namespace";
+
+	public static ClientHttpRequestInterceptor createNamespaceInterceptor(final String namespace) {
+
+        final ClientHttpRequestInterceptor interceptor = new ClientHttpRequestInterceptor() {
+            @Override
+            public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+			HttpHeaders headers = request.getHeaders();
+
+			if (!headers.containsKey(VaultInterceptors.VAULT_NAMESPACE)) {
+				headers.add(VaultInterceptors.VAULT_NAMESPACE, namespace);
+			}
+
+			return execution.execute(request, body);
+            }
+        };
+        return interceptor;
+	}
+}

--- a/common/src/main/java/org/jetbrains/teamcity/vault/support/VaultTemplate.java
+++ b/common/src/main/java/org/jetbrains/teamcity/vault/support/VaultTemplate.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 public class VaultTemplate {
 
     private VaultEndpoint endpoint;
+    private String namespace;
     private ClientHttpRequestFactory requestFactory;
     private SessionManager sessionManager;
 
@@ -64,18 +65,20 @@ public class VaultTemplate {
      * @param sessionManager           must not be {@literal null}.
      */
     public VaultTemplate(@NotNull VaultEndpoint vaultEndpoint,
+                         @NotNull String vaultNamespace,
                          @NotNull ClientHttpRequestFactory clientHttpRequestFactory,
                          @NotNull SessionManager sessionManager) {
         this.endpoint = vaultEndpoint;
+        this.namespace = vaultNamespace;
         this.requestFactory = clientHttpRequestFactory;
         this.sessionManager = sessionManager;
 
-        this.sessionTemplate = createSessionTemplate(vaultEndpoint, clientHttpRequestFactory);
-        this.plainTemplate = UtilKt.createRestTemplate(vaultEndpoint, clientHttpRequestFactory);
+        this.sessionTemplate = createSessionTemplate(vaultEndpoint, namespace, clientHttpRequestFactory);
+        this.plainTemplate = UtilKt.createRestTemplate(vaultEndpoint, namespace, clientHttpRequestFactory);
     }
 
     private VaultTemplate(@NotNull VaultTemplate origin, @NotNull final String wrapTTL) {
-        this(origin.endpoint, origin.requestFactory, origin.sessionManager);
+        this(origin.endpoint, origin.namespace, origin.requestFactory, origin.sessionManager);
         final ClientHttpRequestInterceptor interceptor = new ClientHttpRequestInterceptor() {
             @Override
             public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
@@ -88,9 +91,10 @@ public class VaultTemplate {
     }
 
     private RestTemplate createSessionTemplate(VaultEndpoint endpoint,
+                                               String namespace,
                                                ClientHttpRequestFactory requestFactory) {
 
-        RestTemplate restTemplate = UtilKt.createRestTemplate(endpoint, requestFactory);
+        RestTemplate restTemplate = UtilKt.createRestTemplate(endpoint, namespace, requestFactory);
 
         restTemplate.getInterceptors().add(new ClientHttpRequestInterceptor() {
 

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultConstants.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultConstants.kt
@@ -23,6 +23,7 @@ object VaultConstants {
 
     val PARAMETER_PREFIX = "teamcity.vault"
     val URL_PROPERTY_SUFFIX = ".url"
+    val VAULT_NAMESPACE_PROPERTY_SUFFIX = ".vault.namespace"
     val WRAPPED_TOKEN_PROPERTY_SUFFIX = ".wrapped.token"
     val TOKEN_REFRESH_TIMEOUT_PROPERTY_SUFFIX = ".token.refresh.timeout"
     val FAIL_ON_ERROR_PROPERTY_SUFFIX = ".failOnError"
@@ -40,6 +41,9 @@ object VaultConstants {
         // Feature settings
         @JvmField val NAMESPACE = "namespace"
         @JvmField val DEFAULT_PARAMETER_NAMESPACE = ""
+
+        @JvmField val VAULT_NAMESPACE = "vault-namespace"
+        @JvmField val DEFAULT_VAULT_NAMESPACE = ""
 
         @JvmField val URL = "url"
 

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultFeatureSettings.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultFeatureSettings.kt
@@ -15,15 +15,18 @@
  */
 package org.jetbrains.teamcity.vault
 
-data class VaultFeatureSettings(val namespace: String, val url: String, val endpoint: String, val roleId: String, val secretId: String, val failOnError: Boolean = true) {
+data class VaultFeatureSettings(val namespace: String, val url: String, val vaultNamespace: String, val endpoint: String, val roleId: String, val secretId: String, val failOnError: Boolean = true) {
 
-    constructor(namespace: String, url: String, failOnError: Boolean) : this(namespace, url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, "", "", failOnError)
+    constructor(namespace: String, url: String, failOnError: Boolean) : this(namespace, url, VaultConstants.FeatureSettings.DEFAULT_VAULT_NAMESPACE, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, "", "", failOnError)
 
-    constructor(url: String, roleId: String, secretId: String) : this(VaultConstants.FeatureSettings.DEFAULT_PARAMETER_NAMESPACE, url, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, roleId, secretId)
+    constructor(url: String, roleId: String, secretId: String) : this(VaultConstants.FeatureSettings.DEFAULT_PARAMETER_NAMESPACE, url,  VaultConstants.FeatureSettings.DEFAULT_VAULT_NAMESPACE, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, roleId, secretId)
+
+    constructor(namespace: String, url: String, vaultNamespace: String, failOnError: Boolean) : this(namespace, url, vaultNamespace, VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH, "", "", failOnError)
 
     constructor(map: Map<String, String>) : this(
             map[VaultConstants.FeatureSettings.NAMESPACE] ?: VaultConstants.FeatureSettings.DEFAULT_PARAMETER_NAMESPACE,
             map[VaultConstants.FeatureSettings.URL] ?: "",
+            map[VaultConstants.FeatureSettings.VAULT_NAMESPACE] ?: VaultConstants.FeatureSettings.DEFAULT_VAULT_NAMESPACE,
             // Default value to convert from previous config versions
             (map[VaultConstants.FeatureSettings.ENDPOINT] ?: VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH).removePrefix("/"),
             map[VaultConstants.FeatureSettings.ROLE_ID] ?: "",
@@ -34,6 +37,7 @@ data class VaultFeatureSettings(val namespace: String, val url: String, val endp
     fun toMap(map: MutableMap<String, String>) {
         map[VaultConstants.FeatureSettings.URL] = url
         map[VaultConstants.FeatureSettings.NAMESPACE] = namespace
+        map[VaultConstants.FeatureSettings.VAULT_NAMESPACE] = vaultNamespace
         map[VaultConstants.FeatureSettings.ENDPOINT] = getNormalizedEndpoint()
         map[VaultConstants.FeatureSettings.ROLE_ID] = roleId
         map[VaultConstants.FeatureSettings.SECRET_ID] = secretId
@@ -52,6 +56,7 @@ data class VaultFeatureSettings(val namespace: String, val url: String, val endp
         fun getDefaultParameters(): Map<String, String> {
             return mapOf(
                     VaultConstants.FeatureSettings.NAMESPACE to VaultConstants.FeatureSettings.DEFAULT_PARAMETER_NAMESPACE,
+                    VaultConstants.FeatureSettings.VAULT_NAMESPACE to VaultConstants.FeatureSettings.DEFAULT_VAULT_NAMESPACE,
                     VaultConstants.FeatureSettings.AGENT_SUPPORT_REQUIREMENT to VaultConstants.FeatureSettings.AGENT_SUPPORT_REQUIREMENT_VALUE,
                     VaultConstants.FeatureSettings.ENDPOINT to VaultConstants.FeatureSettings.DEFAULT_ENDPOINT_PATH,
                     VaultConstants.FeatureSettings.URL to "http://localhost:8200"

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/util.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/util.kt
@@ -21,6 +21,7 @@ import jetbrains.buildServer.util.VersionComparatorUtil
 import jetbrains.buildServer.util.ssl.SSLTrustStoreProvider
 import org.jetbrains.teamcity.vault.support.ClientHttpRequestFactoryFactory
 import org.jetbrains.teamcity.vault.support.MappingJackson2HttpMessageConverter
+import org.jetbrains.teamcity.vault.support.VaultInterceptors
 import org.springframework.http.client.ClientHttpRequestFactory
 import org.springframework.http.client.ClientHttpRequestInterceptor
 import org.springframework.http.converter.ByteArrayHttpMessageConverter
@@ -64,11 +65,12 @@ fun createRestTemplate(settings: VaultFeatureSettings, trustStoreProvider: SSLTr
     val factory = createClientHttpRequestFactory(trustStoreProvider)
     // HttpComponents.usingHttpComponents(options, sslConfiguration)
 
-    return createRestTemplate(endpoint, factory)
+    return createRestTemplate(endpoint, settings.vaultNamespace, factory)
 }
 
-fun createRestTemplate(endpoint: VaultEndpoint, factory: ClientHttpRequestFactory): RestTemplate {
+fun createRestTemplate(endpoint: VaultEndpoint, namespace: String, factory: ClientHttpRequestFactory): RestTemplate {
     val template = createRestTemplate()
+    template.getInterceptors().add(VaultInterceptors.createNamespaceInterceptor(namespace))
 
     template.requestFactory = factory
     template.uriTemplateHandler = createUriTemplateHandler(endpoint)

--- a/common/src/test/kotlin/org/jetbrains/teamcity/vault/VaultDevContainer.kt
+++ b/common/src/test/kotlin/org/jetbrains/teamcity/vault/VaultDevContainer.kt
@@ -33,4 +33,7 @@ open class VaultDevContainer(override val token: String = UUID.randomUUID().toSt
 
     override val url: String
         get() = "http://$containerIpAddress:$firstMappedPort"
+
+    override val vaultNamespace: String
+        get() = ""
 }

--- a/common/src/test/kotlin/org/jetbrains/teamcity/vault/VaultDevEnvironment.kt
+++ b/common/src/test/kotlin/org/jetbrains/teamcity/vault/VaultDevEnvironment.kt
@@ -28,10 +28,11 @@ interface VaultDevEnvironment {
     val url: String
     val endpoint: VaultEndpoint
         get() = VaultEndpoint.from(URI.create(url))
+    val vaultNamespace: String
     val simpleSessionManager: SimpleSessionManager
         get() = SimpleSessionManager { VaultToken.of(token) }
 
     fun getTemplate(factory: ClientHttpRequestFactory): VaultTemplate =
-            VaultTemplate(endpoint, factory, simpleSessionManager)
+            VaultTemplate(endpoint, vaultNamespace, factory, simpleSessionManager)
 }
 

--- a/common/src/test/kotlin/org/jetbrains/teamcity/vault/VaultSemiClusterDevContainer.kt
+++ b/common/src/test/kotlin/org/jetbrains/teamcity/vault/VaultSemiClusterDevContainer.kt
@@ -34,6 +34,10 @@ open class VaultSemiClusterDevContainer(val vault: VaultDevEnvironment)
     override val url: String
         get() = "http://localhost:$jetty_port"
 
+    override val vaultNamespace: String
+        get() = ""
+
+
     val used: Boolean
         get() = _used
 

--- a/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultBuildStartContextProcessor.kt
+++ b/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultBuildStartContextProcessor.kt
@@ -100,6 +100,7 @@ class VaultBuildStartContextProcessor(private val connector: VaultConnector) : B
             context.addSharedParameter(getVaultParameterName(settings.namespace, VaultConstants.FAIL_ON_ERROR_PROPERTY_SUFFIX), settings.failOnError.toString())
             context.addSharedParameter(getVaultParameterName(settings.namespace, VaultConstants.WRAPPED_TOKEN_PROPERTY_SUFFIX), wrappedToken)
             context.addSharedParameter(getVaultParameterName(settings.namespace, VaultConstants.URL_PROPERTY_SUFFIX), settings.url)
+            context.addSharedParameter(getVaultParameterName(settings.namespace, VaultConstants.VAULT_NAMESPACE_PROPERTY_SUFFIX), settings.vaultNamespace)
         }
     }
 }

--- a/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultConnector.kt
+++ b/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultConnector.kt
@@ -164,7 +164,7 @@ class VaultConnector(dispatcher: EventDispatcher<BuildServerListener>, private v
             val endpoint = VaultEndpoint.from(URI.create(settings.url))!!
             val factory = createClientHttpRequestFactory(trustStoreProvider)
 
-            val template = VaultTemplate(endpoint, factory, DummySessionManager()).withWrappedResponses("10m")
+            val template = VaultTemplate(endpoint, settings.vaultNamespace, factory, DummySessionManager()).withWrappedResponses("10m")
 
             val login = getAppRoleLogin(settings)
 
@@ -198,7 +198,7 @@ class VaultConnector(dispatcher: EventDispatcher<BuildServerListener>, private v
             val endpoint = VaultEndpoint.from(URI.create(settings.url))!!
             val factory = createClientHttpRequestFactory(trustStoreProvider)
 
-            val template = VaultTemplate(endpoint, factory, DummySessionManager())
+            val template = VaultTemplate(endpoint, settings.vaultNamespace, factory, DummySessionManager())
 
             val login = getAppRoleLogin(settings)
 

--- a/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultJspKeys.kt
+++ b/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultJspKeys.kt
@@ -20,6 +20,7 @@ import org.jetbrains.teamcity.vault.VaultConstants
 class VaultJspKeys {
     val NAMESPACE = VaultConstants.FeatureSettings.NAMESPACE
     val URL = VaultConstants.FeatureSettings.URL
+    val VAULT_NAMESPACE = VaultConstants.FeatureSettings.VAULT_NAMESPACE
 
     val ENDPOINT = VaultConstants.FeatureSettings.ENDPOINT
 

--- a/server/src/main/resources/buildServerResources/editProjectConnectionVault.jsp
+++ b/server/src/main/resources/buildServerResources/editProjectConnectionVault.jsp
@@ -81,7 +81,7 @@
     <td>
         <props:textProperty name="${keys.NAMESPACE}" className="longField"/>
         <span class="error" id="error_${keys.NAMESPACE}"></span>
-        <span class="smallNote">Provide some namespace to use in parameters in case of multiple vault connections.</span>
+        <span class="smallNote">Provide some namespace to use in TeamCity parameters in case of multiple vault connections.</span>
     </td>
 </tr>
 <tr>
@@ -91,6 +91,16 @@
                             className="longField textProperty_max-width js_max-width"/>
         <span class="error" id="error_${keys.URL}"/>
         <span class="smallNote">Format: https://&lt;vaultserver&gt;:&lt;port&gt;</span>
+    </td>
+</tr>
+
+<tr class="advancedSetting">
+    <td><label for="${keys.VAULT_NAMESPACE}">Vault Namespace:</label></td>
+    <td>
+        <props:textProperty name="${keys.VAULT_NAMESPACE}"
+                            className="longField textProperty_max-width js_max-width"/>
+        <span class="error" id="error_${keys.VAULT_NAMESPACE}"/>
+        <span class="smallNote">Vault namespace auth method and secrets engines are housed under.</span>
     </td>
 </tr>
 

--- a/server/src/test/java/org/jetbrains/teamcity/vault/server/VaultConnectorTest.java
+++ b/server/src/test/java/org/jetbrains/teamcity/vault/server/VaultConnectorTest.java
@@ -101,7 +101,7 @@ public class VaultConnectorTest {
         Pair<String, String> credentials = getAppRoleCredentials(template, "auth/" + authMountPath + "/role/testrole");
 
 
-        final Pair<String, String> wrapped = VaultConnector.doRequestWrappedToken(new VaultFeatureSettings("vault", getVault().getUrl(), authMountPath, credentials.getFirst(), credentials.getSecond(), false), SSL_TRUST_STORE_PROVIDER);
+        final Pair<String, String> wrapped = VaultConnector.doRequestWrappedToken(new VaultFeatureSettings("vault", getVault().getUrl(), "", authMountPath, credentials.getFirst(), credentials.getSecond(), false), SSL_TRUST_STORE_PROVIDER);
 
         then(wrapped.getFirst()).isNotNull();
         then(wrapped.getSecond()).isNotNull();
@@ -111,7 +111,7 @@ public class VaultConnectorTest {
                 .wrapped()
                 .initialToken(VaultToken.of(wrapped.getFirst()))
                 .build();
-        final RestTemplate simpleTemplate = UtilKt.createRestTemplate(new VaultFeatureSettings("vault", getVault().getUrl(), authMountPath, "", "", false), SSL_TRUST_STORE_PROVIDER);
+        final RestTemplate simpleTemplate = UtilKt.createRestTemplate(new VaultFeatureSettings("vault", getVault().getUrl(), "", authMountPath, "", "", false), SSL_TRUST_STORE_PROVIDER);
         final CubbyholeAuthentication authentication = new CubbyholeAuthentication(options, simpleTemplate);
         final TaskScheduler scheduler = new ConcurrentTaskScheduler();
 
@@ -131,7 +131,7 @@ public class VaultConnectorTest {
 
     private void doTestWrapperTokenAutoUpdates(String authMountPath) {
         final ClientHttpRequestFactory factory = createClientHttpRequestFactory(SSL_TRUST_STORE_PROVIDER);
-        final VaultTemplate template = new VaultTemplate(getVault().getEndpoint(), factory, () -> VaultToken.of(getVault().getToken()));
+        final VaultTemplate template = new VaultTemplate(getVault().getEndpoint(), getVault().getVaultNamespace(), factory, () -> VaultToken.of(getVault().getToken()));
 
         // Ensure approle auth enabled
         template.opsForSys().authMount(authMountPath, VaultMount.create("approle"));
@@ -148,7 +148,7 @@ public class VaultConnectorTest {
         Pair<String, String> credentials = getAppRoleCredentials(template, "auth/" + authMountPath + "/role/testrole");
 
 
-        final Pair<String, String> wrapped = VaultConnector.doRequestWrappedToken(new VaultFeatureSettings("", getVault().getUrl(), authMountPath, credentials.getFirst(), credentials.getSecond(), true), SSL_TRUST_STORE_PROVIDER);
+        final Pair<String, String> wrapped = VaultConnector.doRequestWrappedToken(new VaultFeatureSettings("", getVault().getUrl(), "", authMountPath, credentials.getFirst(), credentials.getSecond(), true), SSL_TRUST_STORE_PROVIDER);
 
         then(wrapped.getFirst()).isNotNull();
         then(wrapped.getSecond()).isNotNull();
@@ -158,7 +158,7 @@ public class VaultConnectorTest {
                 .wrapped()
                 .initialToken(VaultToken.of(wrapped.getFirst()))
                 .build();
-        final RestTemplate simpleTemplate = UtilKt.createRestTemplate(new VaultFeatureSettings("", getVault().getUrl(), authMountPath, "", "", true), SSL_TRUST_STORE_PROVIDER);
+        final RestTemplate simpleTemplate = UtilKt.createRestTemplate(new VaultFeatureSettings("", getVault().getUrl(), "", authMountPath, "", "", true), SSL_TRUST_STORE_PROVIDER);
         final CubbyholeAuthentication authentication = new CubbyholeAuthentication(options, simpleTemplate);
         final TaskScheduler scheduler = new ConcurrentTaskScheduler();
 


### PR DESCRIPTION
Resolves #20 

~Creating a draft PR to add Vault Namespace support to this plugin. I'm still exploring some ways to better implement the feature but wanted to go ahead and open a PR to allow (potentially) soliciting feedback.~

https://github.com/JetBrains/teamcity-hashicorp-vault-plugin/issues/20#issuecomment-500859676 already does a great job of breaking down the goal of this PR with respect to [Vault's enterprise namespace feature](https://www.vaultproject.io/docs/enterprise/namespaces). As-is, this PR kludges in a duplicative `createNamespaceInterceptor` method that mirrors what was added in the upstream [spring-vault](https://github.com/spring-projects/spring-vault/issues/346) library. I attempted to update to the latest spring-vault release for this codebase to avoid the duplication, but hit too many areas requiring updates that were beyond my skill set. In particular, the existing duplicated `ClientHttpRequestFactoryFactory` and `LifecycleAwareSessionManager` classes require substantial refactoring to operator correctly with the latest spring-vault release (`2.2.1.RELEASE`).