### PR TITLE
Allow http status code 400 when revoking Vault token accessors

### DIFF
--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultResponseErrorHandler.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultResponseErrorHandler.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2000-2020 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.teamcity.vault
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.client.ClientHttpResponse
+import org.springframework.web.client.*
+
+class VaultResponseErrorHandler : DefaultResponseErrorHandler() {
+    override fun handleError(response: ClientHttpResponse?) {
+        val statusCode =  response?.statusCode
+        if(statusCode == HttpStatus.BAD_REQUEST) {
+            return
+        }
+        super.handleError(response)
+    }
+}

--- a/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultConnector.kt
+++ b/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultConnector.kt
@@ -65,6 +65,7 @@ class VaultConnector(dispatcher: EventDispatcher<BuildServerListener>, private v
             val settings = info.connection
             try {
                 val template = createRestTemplate(settings, trustStoreProvider)
+                template.errorHandler = VaultResponseErrorHandler()
                 // Login and retrieve server token
                 val (token, accessor) = getRealToken(template, settings)
 


### PR DESCRIPTION
Fixes #34 

When revoking a token accessor that has already been revoked/is non existing, Vault sends back http status code 400 which throws an exception and prevents the revoke process to complete on server side. 
We allow the process to complete by allowing status code 400 in the case of the revoke action.