### PR TITLE
TW-79903 Docker Registry connection cannot use secrets from Vault

### DIFF
--- a/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/VaultBuildFeature.kt
+++ b/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/VaultBuildFeature.kt
@@ -21,6 +21,8 @@ import jetbrains.buildServer.BuildProblemData
 import jetbrains.buildServer.agent.*
 import jetbrains.buildServer.log.Loggers
 import jetbrains.buildServer.util.EventDispatcher
+import jetbrains.buildServer.util.positioning.PositionAware
+import jetbrains.buildServer.util.positioning.PositionConstraint
 import jetbrains.buildServer.util.ssl.SSLTrustStoreProvider
 import org.jetbrains.teamcity.vault.*
 import org.jetbrains.teamcity.vault.support.LifecycleAwareSessionManager
@@ -34,7 +36,7 @@ import java.util.concurrent.TimeUnit
 
 class VaultBuildFeature(dispatcher: EventDispatcher<AgentLifeCycleListener>,
                         private val trustStoreProvider: SSLTrustStoreProvider,
-                        private val myVaultParametersResolver: VaultParametersResolver) : AgentLifeCycleAdapter() {
+                        private val myVaultParametersResolver: VaultParametersResolver) : AgentLifeCycleAdapter(), PositionAware {
     companion object {
         val LOG = Logger.getInstance(Loggers.AGENT_CATEGORY + "." + VaultBuildFeature::class.java.name)!!
     }
@@ -170,4 +172,8 @@ class VaultBuildFeature(dispatcher: EventDispatcher<AgentLifeCycleListener>,
     override fun buildFinished(build: AgentRunningBuild, buildStatus: BuildFinishedStatus) {
         sessions.remove(build.buildId)
     }
+
+    override fun getOrderId() = "HashiCorpVaultPluginParamsResolvedBuildFeature"
+
+    override fun getConstraint() = PositionConstraint.first()
 }

--- a/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultBuildStartContextProcessor.kt
+++ b/server/src/main/kotlin/org/jetbrains/teamcity/vault/server/VaultBuildStartContextProcessor.kt
@@ -19,10 +19,12 @@ import com.intellij.openapi.diagnostic.Logger
 import jetbrains.buildServer.BuildProblemData
 import jetbrains.buildServer.log.Loggers
 import jetbrains.buildServer.serverSide.*
+import jetbrains.buildServer.util.positioning.PositionAware
+import jetbrains.buildServer.util.positioning.PositionConstraint
 import org.jetbrains.teamcity.vault.*
 import org.jetbrains.teamcity.vault.VaultReferencesUtil.makeVaultReference
 
-class VaultBuildStartContextProcessor(private val connector: VaultConnector) : BuildStartContextProcessor {
+class VaultBuildStartContextProcessor(private val connector: VaultConnector) : BuildStartContextProcessor, PositionAware {
     companion object {
         val LOG = Logger.getInstance(Loggers.SERVER_CATEGORY + "." + VaultBuildStartContextProcessor::class.java.name)!!
 
@@ -125,4 +127,7 @@ class VaultBuildStartContextProcessor(private val connector: VaultConnector) : B
         }
     }
 
+    override fun getOrderId() = "HashiCorpVaultPluginBuildStartContextProcessor"
+
+    override fun getConstraint() = PositionConstraint.last()
 }


### PR DESCRIPTION
Make `VaultBuildStartContextProcessor` and `VaultBuildFeature` position aware and check vault parameters in shared parameters too.

https://youtrack.jetbrains.com/issue/TW-79903/Docker-Registry-connection-cannot-use-secrets-from-Vault