### PR TITLE
fetch approle/secret_id support

### DIFF
--- a/common/src/main/java/org/jetbrains/teamcity/vault/support/VaultTemplate.java
+++ b/common/src/main/java/org/jetbrains/teamcity/vault/support/VaultTemplate.java
@@ -124,6 +124,15 @@ public class VaultTemplate {
         sessionTemplate.getInterceptors().add(interceptor);
     }
 
+    public void removeLastInterceptors() {
+
+        int indexOfLastElementPT = plainTemplate.getInterceptors().size() - 1;
+        plainTemplate.getInterceptors().remove(indexOfLastElementPT);
+
+        int indexOfLastElementST = sessionTemplate.getInterceptors().size() - 1;
+        sessionTemplate.getInterceptors().remove(indexOfLastElementST);
+    }
+
     public VaultSysTemplate opsForSys() {
         return new VaultSysTemplate(this);
     }

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultResolver.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultResolver.kt
@@ -50,8 +50,15 @@ open class VaultResolver(private val trustStoreProvider: SSLTrustStoreProvider) 
 
             for (path in paths.toSet()) {
                 try {
-                    val response = client.read(path.removePrefix("/"))
-                    responses[path] = Response(response)
+                    if (path.startsWith("/auth/") && path.endsWith("/secret-id"))
+                    {
+                        val response = client.write(path.removePrefix("/"), null)
+                        responses[path] = Response(response)
+                    }
+                    else {
+                        val response = client.read(path.removePrefix("/"))
+                        responses[path] = Response(response)
+                    }
                 } catch (e: Exception) {
                     LOG.warn("Failed to fetch data for path '$path'", e)
                     responses[path] = Error(e)

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultResolver.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/VaultResolver.kt
@@ -5,6 +5,7 @@ import com.jayway.jsonpath.JsonPath
 import jetbrains.buildServer.util.ssl.SSLTrustStoreProvider
 import org.jetbrains.teamcity.vault.*
 import org.jetbrains.teamcity.vault.support.VaultTemplate
+import jetbrains.buildServer.serverSide.TeamCityProperties
 import org.springframework.vault.authentication.SimpleSessionManager
 import org.springframework.vault.client.VaultEndpoint
 import org.springframework.vault.support.VaultResponse
@@ -45,15 +46,26 @@ open class VaultResolver(private val trustStoreProvider: SSLTrustStoreProvider) 
 
         private class ResolvingError(message: String) : Exception(message)
 
+        private fun isPathForGetSecretID(path: String): Boolean {
+            if (path.startsWith("/auth/") && path.endsWith("/secret-id"))
+            {
+                return true
+            }
+
+            return false
+        }
+
         private fun fetch(client: VaultTemplate, paths: Collection<String>): HashMap<String, HashiCorpVaultResponse<Exception, VaultResponse>> {
             val responses = HashMap<String, HashiCorpVaultResponse<Exception, VaultResponse>>(paths.size)
 
             for (path in paths.toSet()) {
                 try {
-                    if (path.startsWith("/auth/") && path.endsWith("/secret-id"))
+                    if ( isPathForGetSecretID(path))
                     {
-                        val response = client.write(path.removePrefix("/"), null)
+                        client.wrapResponses(TeamCityProperties.getProperty("teamcity.vault.xVaultWrapTTL", "2m"))
+                        val response = client.write(path.removePrefix("/"), null) 
                         responses[path] = Response(response)
+                        client.removeLastInterceptors()
                     }
                     else {
                         val response = client.read(path.removePrefix("/"))
@@ -92,7 +104,14 @@ open class VaultResolver(private val trustStoreProvider: SSLTrustStoreProvider) 
         @Throws(ResolvingError::class)
         private fun extract(response: VaultResponse, parameter: VaultQuery): String {
             val jsonPath = parameter.jsonPath
-            val data = unwrapKV2IfNeeded(response.data)
+
+            val data: Map<String, Any>?
+            if ( isPathForGetSecretID(parameter.vaultPath))
+                data = unwrapKV2IfNeeded(response.wrapInfo)
+            else {
+                data = unwrapKV2IfNeeded(response.data)
+            }
+            
             if (jsonPath == null) {
                 if (data.isEmpty()) {
                     throw ResolvingError("There's no data in HashiCorp Vault response for '${parameter.vaultPath}'")


### PR DESCRIPTION
we have a use case where a teamcity pipeline authenticated to vault via **approle1**, needs to have access to the **secure_id** for **approle2**.  This workaround is to provide that functionality. 

We would also need following configurations changes to make this work:

The parameter definition would be: 
`%vault:auth/approle/role/approle2/secret-id!/token%`

And policy for approle1 would be:
```
path "auth/approle/role/approle2/secret*" {
  capabilities = ["create", "update", "read"]
}
```


