### PR TITLE
Add namespace to periodical messages sent into the build log

### DIFF
--- a/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/VaultBuildFeature.kt
+++ b/agent/src/main/kotlin/org/jetbrains/teamcity/vault/agent/VaultBuildFeature.kt
@@ -144,7 +144,7 @@ class VaultBuildFeature(
         val logger = runningBuild.buildLogger
         val token: String
         try {
-            val sessionManager = sessionManagerBuilder.buildWithImprovedLogging(settings, logger)
+            val sessionManager = sessionManagerBuilder.buildWithImprovedLogging(settings, namespace, logger)
             sessions[runningBuild.buildId] = sessionManager
             val sessionToken = retrier.execute(
                 Callable {

--- a/common/src/main/kotlin/org/jetbrains/teamcity/vault/SessionManagerBuilder.kt
+++ b/common/src/main/kotlin/org/jetbrains/teamcity/vault/SessionManagerBuilder.kt
@@ -64,13 +64,13 @@ class SessionManagerBuilder(
         return CubbyholeAuthentication(options, restTemplate)
     }
 
-    fun buildWithImprovedLogging(settings: VaultFeatureSettings, logger: BuildProgressLogger): LifecycleAwareSessionManager {
+    fun buildWithImprovedLogging(settings: VaultFeatureSettings, namespace: String, logger: BuildProgressLogger): LifecycleAwareSessionManager {
         val template = buildRestTemplate(settings)
         val authentication = buildClientAuthentication(settings, template)
 
 
         return LifecycleAwareSessionManager(
-            authentication, scheduler, template,
+            authentication, scheduler, template, namespace,
             LifecycleAwareSessionManager.FixedTimeoutRefreshTrigger(getTimeoutSeconds(settings), TimeUnit.SECONDS), logger
         )
     }


### PR DESCRIPTION
Right now it's impossible to distinguish the two `HashiCorp Vault token exceed validity TTL threshold and would be dropped.` messages coming from different connections.